### PR TITLE
Use io-write module instead of io-writev

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,16 +9,12 @@ on:
 jobs:
   luacheck:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/mah0x211/lua-ci:latest
     steps:
     -
       name: Checkout
       uses: actions/checkout@v2
-    -
-      name: Setup Lua
-      uses: leafo/gh-actions-lua@v8
-    -
-      name: Setup Luarocks
-      uses: leafo/gh-actions-luarocks@v4
     -
       name: Install Tools
       run: luarocks install luacheck
@@ -29,29 +25,27 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/mah0x211/lua-ci:latest
     strategy:
       matrix:
         lua-version:
-          - "5.1"
-          - "5.2"
-          - "5.3"
-          - "5.4"
-          - "luajit-2.0.5"
-          - "luajit-openresty"
+          - "5.1.:latest"
+          - "5.2.:latest"
+          - "5.3.:latest"
+          - "5.4.:latest"
+          - "lj-v2.1:latest"
     steps:
+    -
+      name: Switch Lua Version
+      run: |
+        lenv -g use ${{ matrix.lua-version }}
+        lua -v || true
     -
       name: Checkout
       uses: actions/checkout@v2
       with:
         submodules: 'true'
-    -
-      name: Setup Lua ${{ matrix.lua-version }}
-      uses: leafo/gh-actions-lua@v8
-      with:
-        luaVersion: ${{ matrix.lua-version }}
-    -
-      name: Setup Luarocks
-      uses: leafo/gh-actions-luarocks@v4
     -
       name: Install Tools
       run: |
@@ -69,6 +63,7 @@ jobs:
         testcase --coverage test/
     -
       name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
       with:
+        token: ${{ secrets.CODECOV_TOKEN }}
         flags: unittests

--- a/rockspecs/io-writer-dev-1.rockspec
+++ b/rockspecs/io-writer-dev-1.rockspec
@@ -16,7 +16,7 @@ dependencies = {
     "io-isfile >= 0.1.0",
     "io-fopen >= 0.1.3",
     "io-fileno >= 0.1.0",
-    "io-writev >= 0.1.0",
+    "io-write >= 0.3.0",
     "metamodule >= 0.5.0",
     "time-clock >= 0.4.0",
 }

--- a/test/writer_test.lua
+++ b/test/writer_test.lua
@@ -8,6 +8,35 @@ local gettime = require('time.clock').gettime
 
 local TEST_TXT = 'test.txt'
 
+local function with_swapped_upvalues(fn, replacements, cb)
+    local originals = {}
+
+    for i = 1, math.huge do
+        local name, value = debug.getupvalue(fn, i)
+        if not name then
+            break
+        elseif replacements[name] ~= nil then
+            originals[name] = value
+            debug.setupvalue(fn, i, replacements[name])
+        end
+    end
+
+    local ok, err = pcall(cb)
+
+    for i = 1, math.huge do
+        local name = debug.getupvalue(fn, i)
+        if not name then
+            break
+        elseif originals[name] ~= nil then
+            debug.setupvalue(fn, i, originals[name])
+        end
+    end
+
+    if not ok then
+        error(err, 0)
+    end
+end
+
 function testcase.before_all()
     local f = assert(io.open(TEST_TXT, 'w'))
     f:write('hello world')
@@ -110,6 +139,52 @@ function testcase.write()
     -- test that throws an error if no data arguments are specified
     err = assert.throws(w.write, w)
     assert.match(err, 'data argument is required')
+end
+
+function testcase.write_uses_io_write_table()
+    local calls = {}
+    local wait_count = 0
+    local f = assert(io.tmpfile())
+    local w = assert(writer.new(f))
+
+    with_swapped_upvalues(w.write, {
+        write = function(_, data)
+            calls[#calls + 1] = data
+            if #calls == 1 then
+                return 5, nil, true, {
+                    'l',
+                    'true',
+                    'bar',
+                }
+            end
+            return 8
+        end,
+        wait_writable = function(fd)
+            wait_count = wait_count + 1
+            return fd
+        end,
+    }, function()
+        local n, err, again, remain = w:write('foo', nil, true, 'bar')
+
+        assert.equal(n, 13)
+        assert.is_nil(err)
+        assert.is_nil(again)
+        assert.is_nil(remain)
+    end)
+
+    assert(w:close())
+    f:close()
+    assert.equal(wait_count, 1)
+    assert.is_table(calls[1])
+    assert.equal(calls[1][1], 'foo')
+    assert.equal(calls[1][2], 'nil')
+    assert.equal(calls[1][3], 'true')
+    assert.equal(calls[1][4], 'bar')
+    assert.is_table(calls[2])
+    assert.equal(calls[2][1], 'l')
+    assert.equal(calls[2][2], 'true')
+    assert.equal(calls[2][3], 'bar')
+    assert.is_nil(calls[2][4])
 end
 
 function testcase.write_timeout()

--- a/writer.lua
+++ b/writer.lua
@@ -19,14 +19,13 @@
 -- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 -- THE SOFTWARE.
 --
-local concat = table.concat
 local select = select
 local type = type
 local tostring = tostring
 local isfile = require('io.isfile')
 local fopen = require('io.fopen')
 local fileno = require('io.fileno')
-local writev = require('io.writev')
+local write = require('io.write')
 local wait_writable = require('gpoll').wait_writable
 local new_deadline = require('time.clock.deadline').new
 -- constants
@@ -100,10 +99,9 @@ function Writer:write(...)
         return nil, EBADF:new('writer is closed')
     end
 
-    local str = concat(args)
     local sec = self.waitsec
     local deadline = sec and new_deadline(sec)
-    local n, err, again, remain = writev(fd, str)
+    local n, err, again, remain = write(fd, args)
     local total = 0
     while again do
         total = total + n
@@ -121,7 +119,7 @@ function Writer:write(...)
             return total, err, again
         end
         -- write remaining data
-        n, err, again, remain = writev(fd, remain)
+        n, err, again, remain = write(fd, remain)
     end
 
     if n then


### PR DESCRIPTION
This pull request updates the implementation of the `Writer:write` method to use the `io.write` module instead of `io.writev`, and adapts the code and tests accordingly. The change improves how write arguments are handled and tested, and updates dependencies to reflect the new requirement.

**Dependency and Implementation Updates:**

* Updated the dependency in `rockspecs/io-writer-dev-1.rockspec` to require `io-write >= 0.3.0` instead of `io-writev >= 0.1.0`.
* Changed the implementation in `writer.lua` to use `require('io.write')` and replaced all calls to `writev` with `write`, passing argument tables directly instead of concatenating strings. [[1]](diffhunk://#diff-3ceb161c8f396b81c4ac9afd021c5addb4a540a780130b4277defb4ce2745a69L22-R28) [[2]](diffhunk://#diff-3ceb161c8f396b81c4ac9afd021c5addb4a540a780130b4277defb4ce2745a69L103-R104) [[3]](diffhunk://#diff-3ceb161c8f396b81c4ac9afd021c5addb4a540a780130b4277defb4ce2745a69L124-R122)

**Testing Improvements:**

* Added a utility function `with_swapped_upvalues` to `test/writer_test.lua` for swapping upvalues in functions during tests, enabling more flexible mocking and test isolation.
* Introduced a new test `testcase.write_uses_io_write_table` to verify that the `write` method correctly passes argument tables to the underlying `io.write` function, and that the method handles return values and state as expected.