### PR TITLE
Update io-write to v0.4.0

### DIFF
--- a/rockspecs/io-writer-dev-1.rockspec
+++ b/rockspecs/io-writer-dev-1.rockspec
@@ -16,7 +16,7 @@ dependencies = {
     "io-isfile >= 0.1.0",
     "io-fopen >= 0.1.3",
     "io-fileno >= 0.1.0",
-    "io-write >= 0.3.0",
+    "io-write >= 0.4.0",
     "metamodule >= 0.5.0",
     "time-clock >= 0.4.0",
 }

--- a/writer.lua
+++ b/writer.lua
@@ -117,7 +117,7 @@ function Writer:write(...)
 
     local sec = self.waitsec
     local deadline = sec and new_deadline(sec)
-    local n, err, again, remain = write(fd, args)
+    local n, err, again = write(fd, args)
     local total = 0
     while again do
         total = total + n
@@ -134,8 +134,8 @@ function Writer:write(...)
         if not fd then
             return total, err, again
         end
-        -- write remaining data
-        n, err, again, remain = write(fd, remain)
+        -- write remaining data (total = bytes already written = start pos)
+        n, err, again = write(fd, args, nil, total)
     end
 
     if n then


### PR DESCRIPTION
This pull request updates the `io-writer` module to support a newer version of its dependency and adjusts the `Writer:write` function to accommodate changes in the underlying `io-write` API. The most important changes are:

Dependency update:

* Updated the required version of the `io-write` dependency from `>= 0.3.0` to `>= 0.4.0` in the `rockspecs/io-writer-dev-1.rockspec` file, ensuring compatibility with the latest API changes.

Code changes for new API:

* Modified the `Writer:write` function in `writer.lua` to match the updated `io-write` API: removed the `remain` variable from the initial call to `write`, and updated the subsequent call to `write` to pass the current write position (`total`) as an offset instead of using `remain`. [[1]](diffhunk://#diff-3ceb161c8f396b81c4ac9afd021c5addb4a540a780130b4277defb4ce2745a69L120-R120) [[2]](diffhunk://#diff-3ceb161c8f396b81c4ac9afd021c5addb4a540a780130b4277defb4ce2745a69L137-R138)